### PR TITLE
Update ExternalAuthenticatedRole.php

### DIFF
--- a/code/ExternalAuthenticatedRole.php
+++ b/code/ExternalAuthenticatedRole.php
@@ -143,10 +143,12 @@ class ExternalAuthenticatedRole_Validator extends Extension {
             $id = $_REQUEST['ctf']['childID'];
         } elseif(isset($_REQUEST['ID'])) {
             $id = $_REQUEST['ID'];
+        } elseif(isset($form->getRecord()->ID)) {
+            $id = $form->getRecord()->ID;
         }
 
         if(is_object($member) && $member->ID != $id) {
-            $field = $form->dataFieldByName('External_Anchor');
+            $field = $form->Fields()->dataFieldByName('External_Anchor');
             $this->owner->validationError($field->id(),
                 _t('ExternalAuthenticator.UserExists', 'There already exists a member with this account name'),
                 'required');


### PR DESCRIPTION
Allow editing of user record without getting duplicated (LDAP) identifier error.
Fixed bug in error message on duplicated external anchor.